### PR TITLE
feat(LoginDialog): add UI to enter auth token

### DIFF
--- a/sources/login/LoginDialog.cpp
+++ b/sources/login/LoginDialog.cpp
@@ -72,7 +72,17 @@ void LoginDialog::on_login_pushButton_clicked()
 	loginData.domain = ui->domain_lineEdit->text();
 	loginData.username = ui->username_lineEdit->text();
 	loginData.password = ui->password_lineEdit->text();
-	loginData.token = "";
+	loginData.token = ui->token_lineEdit->text();
+
+	if (loginData.password.isEmpty() && loginData.token.isEmpty()) {
+		setError("Please enter your password or token.");
+		return;
+	}
+
+	if (!loginData.password.isEmpty() && !loginData.token.isEmpty()) {
+		setError("Password and token are not allowed at the same time. Please enter only one of them.");
+		return;
+	}
 
 	loginData.saveToSettings (settings);
 	loginToServer (loginData);

--- a/sources/login/LoginDialog.ui
+++ b/sources/login/LoginDialog.ui
@@ -52,46 +52,7 @@
     </layout>
    </item>
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>48</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="username_lineEdit">
-       <property name="maxLength">
-        <number>512</number>
-       </property>
-       <property name="placeholderText">
-        <string>Username</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLineEdit" name="password_lineEdit">
-       <property name="maxLength">
-        <number>512</number>
-       </property>
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-       <property name="placeholderText">
-        <string>Password</string>
-       </property>
-      </widget>
-     </item>
+    <layout class="QGridLayout" name="gridLayout" columnstretch="1,5">
      <item row="0" column="0">
       <widget class="QLabel" name="domain_label">
        <property name="toolTip">
@@ -102,6 +63,16 @@
        </property>
        <property name="buddy">
         <cstring>domain_lineEdit</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="username_lineEdit">
+       <property name="maxLength">
+        <number>512</number>
+       </property>
+       <property name="placeholderText">
+        <string>Username</string>
        </property>
       </widget>
      </item>
@@ -141,6 +112,59 @@
        </property>
        <property name="placeholderText">
         <string>Domain</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="password_lineEdit">
+       <property name="maxLength">
+        <number>512</number>
+       </property>
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+       <property name="placeholderText">
+        <string>Password</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="toolTip">
+      <string>Some servers uses SSO auth. This client doesn't support it natevly.
+Instead you should bypass SSO auth into your browser, find 'MMAUTHTOKEN'
+cookie in developer tools and copy its content into field below.
+Password and token can't be used simultenusly</string>
+     </property>
+     <property name="text">
+      <string>Token authentication</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,5">
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="token_lineEdit">
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+       <property name="placeholderText">
+        <string>Token (optional)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="token_label">
+       <property name="toolTip">
+        <string>Token that should be used for authentication instead of password</string>
+       </property>
+       <property name="text">
+        <string>&amp;Token</string>
+       </property>
+       <property name="buddy">
+        <cstring>token_lineEdit</cstring>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Fix #14

UI:
![image](https://github.com/nuclear868/mattermost-qt/assets/6306608/85dc5523-ad88-43a5-b45d-4a148d3aa28c)
![image](https://github.com/nuclear868/mattermost-qt/assets/6306608/c61e51f2-737a-4dc8-964a-76e0afa484be)
